### PR TITLE
Documentation

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -41,7 +41,7 @@ impl EntityBuilder {
     }
 
     /// Adds a component to an entity, or sets its value if the component is present.
-    pub fn add<C>(&mut self, component: C)
+    pub fn add<C>(&mut self, component: C) -> &mut Self
     where
         C: Component,
     {
@@ -56,7 +56,7 @@ impl EntityBuilder {
             debug_assert!(ty == ComponentTypeId::of::<C>());
             debug_assert!(meta == ComponentMeta::of::<C>());
             unsafe { self.replace(component, offset) }
-            return;
+            return self;
         }
 
         let size = mem::size_of::<C>();
@@ -80,6 +80,7 @@ impl EntityBuilder {
         self.component_data.push((type_id, meta, self.cursor));
 
         self.cursor += size;
+        self
     }
 
     unsafe fn replace<C>(&mut self, component: C, offset: usize) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -99,7 +99,7 @@ impl EntityBuilder {
         }
     }
 
-    /// This one seems redudent, since spawning clears the internal components.
+    /// Builds the components into an entity without deallocating the internals.
     pub fn build_one(&mut self) -> BuiltEntity {
         BuiltEntity {
             builder: CowMut::Borrowed(self),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,6 +10,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
+/// A builder that simplifies the creation of a single entity.
 #[derive(Default)]
 pub struct EntityBuilder {
     /// Raw component storage. Each component is written
@@ -27,6 +28,9 @@ impl EntityBuilder {
         Self::default()
     }
 
+    /// Adds a component to an entity, or sets its value if the component is present.
+    ///
+    /// Returns `Self` such that method calls for `EntityBuilder`can be chained.
     pub fn with<C>(mut self, component: C) -> Self
     where
         C: Component,
@@ -36,7 +40,8 @@ impl EntityBuilder {
         self
     }
 
-    pub fn add<C>(&mut self, component: C) -> &mut Self
+    /// Adds a component to an entity, or sets its value if the component is present.
+    pub fn add<C>(&mut self, component: C)
     where
         C: Component,
     {
@@ -51,7 +56,7 @@ impl EntityBuilder {
             debug_assert!(ty == ComponentTypeId::of::<C>());
             debug_assert!(meta == ComponentMeta::of::<C>());
             unsafe { self.replace(component, offset) }
-            return self;
+            return;
         }
 
         let size = mem::size_of::<C>();
@@ -75,8 +80,6 @@ impl EntityBuilder {
         self.component_data.push((type_id, meta, self.cursor));
 
         self.cursor += size;
-
-        self
     }
 
     unsafe fn replace<C>(&mut self, component: C, offset: usize) {
@@ -87,6 +90,7 @@ impl EntityBuilder {
             .write_unaligned(component);
     }
 
+    /// Builds the components into an entity that can be inserted into a world.
     pub fn build(self) -> BuiltEntity<'static> {
         BuiltEntity {
             builder: CowMut::Owned(self),
@@ -94,6 +98,7 @@ impl EntityBuilder {
         }
     }
 
+    /// This one seems redudent, since spawning clears the internal components.
     pub fn build_one(&mut self) -> BuiltEntity {
         BuiltEntity {
             builder: CowMut::Borrowed(self),
@@ -141,6 +146,7 @@ impl<'a> IntoComponentSource for BuiltEntity<'a> {
 }
 
 impl<'a> BuiltEntity<'a> {
+    /// Spawns the built entity into the given world.
     pub fn spawn_in(self, world: &mut World) -> Entity {
         world.spawn(self)[0]
     }

--- a/src/entity_ref.rs
+++ b/src/entity_ref.rs
@@ -2,12 +2,16 @@ use crate::{Entity, World};
 use legion::borrow::Ref;
 use legion::storage::Component;
 
+/// A refrence to a `World` and `Entity` to allow for easy retrival of components.
 pub struct EntityRef<'a> {
     pub(crate) world: &'a World,
     pub(crate) entity: Entity,
 }
 
 impl<'a> EntityRef<'a> {
+    /// Borrows component data `C` from the referenced world and entity.
+    ///
+    /// Panics if the entity was not found or did not contain the specified component.
     pub fn get<C>(&self) -> Ref<C>
     where
         C: Component,
@@ -15,6 +19,10 @@ impl<'a> EntityRef<'a> {
         self.try_get().unwrap()
     }
 
+    /// Borrows component data `C` from the referenced world and entity.
+    ///
+    /// Returns `Some(data)` if the entity was found and contains the specified data.
+    /// Otherwise `None` is returned.
     pub fn try_get<C>(&self) -> Option<Ref<C>>
     where
         C: Component,
@@ -22,7 +30,13 @@ impl<'a> EntityRef<'a> {
         self.world.try_get(self.entity)
     }
 
+    /// Returns the referenced entity.
     pub fn entity(&self) -> Entity {
         self.entity
+    }
+
+    /// Returns the referenced world.
+    pub fn world(&self) -> &'a World {
+        self.world
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -82,7 +82,7 @@ impl EventHandlers {
         }
     }
 
-    /// Triggers an event.
+    /// Emeits the given event `E` with given resources and world.
     pub fn trigger<E>(&self, resources: &impl ResourcesProvider, world: &mut World, event: E)
     where
         E: Event,

--- a/src/events.rs
+++ b/src/events.rs
@@ -82,7 +82,7 @@ impl EventHandlers {
         }
     }
 
-    /// Emeits the given event `E` with given resources and world.
+    /// Emits the given event `E` with the given resources and world.
     pub fn trigger<E>(&self, resources: &impl ResourcesProvider, world: &mut World, event: E)
     where
         E: Event,

--- a/src/query.rs
+++ b/src/query.rs
@@ -4,6 +4,7 @@ use legion::query::View;
 use legion::query::{IntoQuery, ViewElement};
 use legion::storage::Component;
 
+/// A query that references a given world.
 pub struct QueryBorrow<'a, Q>
 where
     Q: Query,

--- a/src/system.rs
+++ b/src/system.rs
@@ -6,7 +6,7 @@ pub trait RawSystem: Send + Sync + 'static {
     /// Runs the system with the given resources and world.
     fn run(&self, resources: &ResourcesEnum, world: &mut World, executor: &Executor);
 
-    /// Set up the system with the given resources and world. 
+    /// Set up the system with the given resources and world.
     fn set_up(&mut self, resources: &mut OwnedResources, world: &mut World);
 }
 
@@ -34,7 +34,7 @@ impl Executor {
     pub fn add_boxed(&mut self, system: Box<dyn RawSystem>) {
         self.systems.push(system);
     }
-    
+
     /// Adds the given system to the executor.
     ///
     /// Returns `Self` such that method calls for `Executor` can be chained.

--- a/src/system.rs
+++ b/src/system.rs
@@ -3,7 +3,10 @@ use crate::{OwnedResources, ResourcesProvider, World};
 
 #[doc(hidden)]
 pub trait RawSystem: Send + Sync + 'static {
+    /// Runs the system with the given resources and world.
     fn run(&self, resources: &ResourcesEnum, world: &mut World, executor: &Executor);
+
+    /// Set up the system with the given resources and world. 
     fn set_up(&mut self, resources: &mut OwnedResources, world: &mut World);
 }
 
@@ -22,29 +25,40 @@ impl Executor {
         Self::default()
     }
 
+    /// Adds the given system to the executor.
     pub fn add(&mut self, system: impl RawSystem) {
         self.add_boxed(Box::new(system));
     }
 
+    /// Adds the given system to the exectuor.
     pub fn add_boxed(&mut self, system: Box<dyn RawSystem>) {
         self.systems.push(system);
     }
-
+    
+    /// Adds the given system to the executor.
+    ///
+    /// Returns `Self` such that method calls for `Executor` can be chained.
     pub fn with(mut self, system: impl RawSystem) -> Self {
         self.add(system);
         self
     }
 
+    /// Returns the number of system registrede for this executor.
     pub fn num_systems(&self) -> usize {
         self.systems.len()
     }
 
+    /// Setsup each system registred for this executor.
+    ///
+    /// # Note
+    /// This function should only be called once.
     pub fn set_up(&mut self, resources: &mut OwnedResources, world: &mut World) {
         for system in &mut self.systems {
             system.set_up(resources, world);
         }
     }
 
+    /// Executes the systems in series.
     pub fn execute(&self, resources: &impl ResourcesProvider, world: &mut World) {
         for system in &self.systems {
             system.run(&resources.as_resources_ref(), world, self);

--- a/src/world.rs
+++ b/src/world.rs
@@ -4,7 +4,7 @@ use legion::borrow::{Ref, RefMut};
 use legion::entity::Entity;
 use legion::query::IntoQuery;
 use legion::storage::Component;
-use legion::world::{EntityMutationError, IntoComponentSource, ComponentTypeTupleSet};
+use legion::world::{ComponentTypeTupleSet, EntityMutationError, IntoComponentSource};
 
 type LegionWorld = legion::world::World;
 
@@ -53,7 +53,6 @@ impl World {
         self.inner.add_component(entity, component)
     }
 
-
     /// Removes a component from an entity.
     ///
     /// # Notes
@@ -61,7 +60,7 @@ impl World {
     /// causing a memory copy of the entity to a new location. This function should not be used
     /// multiple times in successive order.
     ///
-    /// `World::batch_remove` should be used for removing multiple components from an entity at once., 
+    /// `World::batch_remove` should be used for removing multiple components from an entity at once.,
     pub fn remove<C>(&mut self, entity: Entity) -> Result<(), EntityMutationError>
     where
         C: Component,
@@ -182,7 +181,7 @@ impl World {
         }
     }
 
-    /// Creates a query for the world. 
+    /// Creates a query for the world.
     pub fn query<Q>(&mut self) -> QueryBorrow<Q>
     where
         Q: Query,
@@ -209,7 +208,7 @@ impl World {
         self.inner.defrag(budget)
     }
 
-    /// Delete all entities and their associated data. 
+    /// Delete all entities and their associated data.
     /// This leaves subscriptions and the command buffer intact.
     pub fn clear(&mut self) {
         self.inner.delete_all()

--- a/src/world.rs
+++ b/src/world.rs
@@ -4,31 +4,47 @@ use legion::borrow::{Ref, RefMut};
 use legion::entity::Entity;
 use legion::query::IntoQuery;
 use legion::storage::Component;
-use legion::world::EntityMutationError;
-use legion::world::IntoComponentSource;
+use legion::world::{EntityMutationError, IntoComponentSource, ComponentTypeTupleSet};
 
 type LegionWorld = legion::world::World;
 
+/// Contains queryable collections of data associated with `Entity`s.
 #[derive(Default)]
 pub struct World {
     inner: LegionWorld,
 }
 
 impl World {
+    /// Creates a new Fecs World
     pub fn new() -> Self {
         World {
             inner: LegionWorld::default(),
         }
     }
 
+    /// Spawns multiple new entities into the world with the given components,
+    /// the `EntityBuilder` and `BuiltEntity::spawn_in` is prefered for spawning
+    /// a single entity. You can use the `EntityBuilder::build` to create multiple
+    /// entities, this method can then be used to batch insert them.
+    ///
+    /// Returns a slice of entity handlers for the spawned entities.
     pub fn spawn(&mut self, components: impl IntoComponentSource) -> &[Entity] {
         self.inner.insert((), components)
     }
 
+    /// Despawns the given `Entity` from the `World`.
+    ///
+    /// Returns `true` if the entity was despawned; else `false`.
     pub fn despawn(&mut self, entity: Entity) -> bool {
         self.inner.delete(entity)
     }
 
+    /// Adds a component to an entity, or sets its value if the component is already present.
+    ///
+    /// # Notes
+    /// This function has the overhead of moving the entity to either an existing or new archetype,
+    /// causing a memory copy of the entity to a new location. This function should not be used
+    /// multiple times in successive order.
     pub fn add(
         &mut self,
         entity: Entity,
@@ -37,6 +53,15 @@ impl World {
         self.inner.add_component(entity, component)
     }
 
+
+    /// Removes a component from an entity.
+    ///
+    /// # Notes
+    /// This function has the overhead of moving the entity to either an existing or new archetype,
+    /// causing a memory copy of the entity to a new location. This function should not be used
+    /// multiple times in successive order.
+    ///
+    /// `World::batch_remove` should be used for removing multiple components from an entity at once., 
     pub fn remove<C>(&mut self, entity: Entity) -> Result<(), EntityMutationError>
     where
         C: Component,
@@ -44,6 +69,22 @@ impl World {
         self.inner.remove_component::<C>(entity)
     }
 
+    /// Removes multiple components from an entity
+    ///
+    /// # Notes
+    /// This function is provided for bulk deleting components from an entity. This difference between this
+    /// function and `remove_component` is this allows us to remove multiple components and still only
+    /// perform a single move operation of the entity.
+    pub fn batch_remove<C>(&mut self, entity: Entity) -> Result<(), EntityMutationError>
+    where
+        C: ComponentTypeTupleSet,
+    {
+        self.inner.remove_components::<C>(entity)
+    }
+
+    /// Borrows component data `C` for the given entity.
+    ///
+    /// Panics if the entity was not found or did not contain the specified component.
     pub fn get<C>(&self, entity: Entity) -> Ref<C>
     where
         C: Component,
@@ -56,6 +97,9 @@ impl World {
         })
     }
 
+    /// Mutably borrows component data `C` for the given entity.
+    ///
+    /// Panics if the neity was not found or did not contain the specified component.
     pub fn get_mut<C>(&mut self, entity: Entity) -> RefMut<C>
     where
         C: Component,
@@ -83,6 +127,10 @@ impl World {
         })
     }
 
+    /// Borrows component data `C` for the given entity.
+    ///
+    /// Returns `Some(data)` if the entity was found and contains the specified data.
+    /// Otherwise `None` is returned.
     pub fn try_get<C>(&self, entity: Entity) -> Option<Ref<C>>
     where
         C: Component,
@@ -90,6 +138,10 @@ impl World {
         self.inner.get_component(entity)
     }
 
+    /// Mutably borrows component data `C` for the given entity.
+    ///
+    /// Returns `Some(data)` if the entity was found and contains the specified data.
+    /// Otherwise `None` is returned.
     pub fn try_get_mut<C>(&mut self, entity: Entity) -> Option<RefMut<C>>
     where
         C: Component,
@@ -107,6 +159,7 @@ impl World {
         self.inner.get_component_mut_unchecked(entity)
     }
 
+    /// Checks if the given entity contains the component `C`.
     pub fn has<C>(&self, entity: Entity) -> bool
     where
         C: Component,
@@ -114,6 +167,10 @@ impl World {
         self.try_get::<C>(entity).is_some()
     }
 
+    /// Creates a refrence for the world and the given entity.
+    ///
+    /// Returns `Some(refrence)` if the entity is alive otherwise.
+    /// Otherwise `None` is returned.
     pub fn entity(&self, entity: Entity) -> Option<EntityRef> {
         if self.is_alive(entity) {
             Some(EntityRef {
@@ -125,6 +182,7 @@ impl World {
         }
     }
 
+    /// Creates a query for the world. 
     pub fn query<Q>(&mut self) -> QueryBorrow<Q>
     where
         Q: Query,
@@ -135,22 +193,34 @@ impl World {
         }
     }
 
+    /// Determines if the given `Entity` is alive within this `World`.
     pub fn is_alive(&self, entity: Entity) -> bool {
         self.inner.is_alive(entity)
     }
 
+    /// Iteratively defragments the world's internal memory.
+    ///
+    /// This compacts entities into fewer more continuous chunks.
+    ///
+    /// `budget` describes the maximum number of entities that can be moved
+    /// in one call. Subsequent calls to `defrag` will resume progress from the
+    /// previous call.
     pub fn defrag(&mut self, budget: Option<usize>) {
         self.inner.defrag(budget)
     }
 
+    /// Delete all entities and their associated data. 
+    /// This leaves subscriptions and the command buffer intact.
     pub fn clear(&mut self) {
         self.inner.delete_all()
     }
 
+    /// Borrows `Legion::World` which `Fecs::World` is based on.
     pub fn inner(&self) -> &LegionWorld {
         &self.inner
     }
 
+    /// Mutable borrows `Legion::World` which `Fecs::World` is based on.
     pub fn inner_mut(&mut self) -> &mut LegionWorld {
         &mut self.inner
     }


### PR DESCRIPTION
This PR adds documentation to all publicly exposed functions. 
This PR also adds `fecs::World::batch_remove`, Legion does not expose `legion::World::add_components` to allow for `fecs::World::batch_add`.

A few notes reading through the source.
1. `Executor::set_up` should only be run once or should we keep track of which systems have been set up correctly? This can be easily be done by tracking the length at each call to `Executor::set_up` since there's no way of removing systems.
2. `EntityBuilder::add` should not be exposed publicly since `EntityBuilder::with` should be preferred?
3. `EntityBuilder::build_one` seems strange and useless since spawning the entity into a world resets the builder, it does however reuse the internal vectors?
4. `World::try_get` should be renamed `World::get` and `World::get` should be removed in favour of `Option::unwrap`?